### PR TITLE
Unbind should unbind globally if key was bound globally

### DIFF
--- a/plugins/global-bind/index.js
+++ b/plugins/global-bind/index.js
@@ -11,6 +11,7 @@
 module.exports = function (Combokeys) {
   var globalCallbacks = {}
   var originalStopCallback = Combokeys.stopCallback
+  var originalUnbind = Combokeys.unbind
 
   Combokeys.stopCallback = function (e, element, combo, sequence) {
     if (globalCallbacks[combo] || globalCallbacks[sequence]) {
@@ -33,8 +34,8 @@ module.exports = function (Combokeys) {
     globalCallbacks[keys] = true
   }
 
-  Combokeys.unbindGlobal = function (keys, action) {
-    this.unbind(keys, action)
+  Combokeys.unbind = function (keys, action) {
+    originalUnbind.call(this, keys, action)
 
     if (keys instanceof Array) {
       for (var i = 0; i < keys.length; i++) {

--- a/plugins/global-bind/index.js
+++ b/plugins/global-bind/index.js
@@ -33,5 +33,18 @@ module.exports = function (Combokeys) {
     globalCallbacks[keys] = true
   }
 
+  Combokeys.unbindGlobal = function (keys, action) {
+    this.unbind(keys, action)
+
+    if (keys instanceof Array) {
+      for (var i = 0; i < keys.length; i++) {
+        globalCallbacks[keys[i]] = false
+      }
+      return
+    }
+
+    globalCallbacks[keys] = false
+  }
+
   return Combokeys
 }

--- a/test/plugins/global-bind.js
+++ b/test/plugins/global-bind.js
@@ -102,7 +102,7 @@ describe('combokeys.unbind', function () {
 
     combokeys.unbind('a')
     KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
-    assert.equal(spy.callCount, 1, 'callback for a should not fire after unbindGlobal')
+    assert.equal(spy.callCount, 1, 'callback for a should not fire after unbind')
 
     // If we now bind the same key without bindGlobal,
     // it's not bound globally

--- a/test/plugins/global-bind.js
+++ b/test/plugins/global-bind.js
@@ -103,3 +103,25 @@ describe('combokeys.unbind', function () {
     assert.equal(spy.callCount, 1, 'callback for a should not fire after unbind')
   })
 })
+
+describe('combokeys.unbindGlobal', function () {
+  it('unbindGlobal removes the global binding', function () {
+    var spy = sinon.spy()
+    var combokeys = new Combokeys(document)
+    var el = document.createElement('input')
+    document.body.appendChild(el)
+    require('../../plugins/global-bind')(combokeys)
+    combokeys.bindGlobal('a', spy)
+    KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
+    assert.equal(spy.callCount, 1, 'callback for a should fire')
+
+    combokeys.unbindGlobal('a')
+    KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
+    assert.equal(spy.callCount, 1, 'callback for a should not fire after unbindGlobal')
+
+    // If we now bind the same key, it's not bound globally
+    combokeys.bind('a', spy)
+    KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
+    assert.equal(spy.callCount, 1, 'callback for a should not fire in an input after bind')
+  })
+})

--- a/test/plugins/global-bind.js
+++ b/test/plugins/global-bind.js
@@ -93,21 +93,6 @@ describe('combokeys.unbind', function () {
   it('unbind works', function () {
     var spy = sinon.spy()
     var combokeys = new Combokeys(document)
-    require('../../plugins/global-bind')(combokeys)
-    combokeys.bindGlobal('a', spy)
-    KeyEvent.simulate('a'.charCodeAt(0), 65)
-    assert.equal(spy.callCount, 1, 'callback for a should fire')
-
-    combokeys.unbind('a')
-    KeyEvent.simulate('a'.charCodeAt(0), 65)
-    assert.equal(spy.callCount, 1, 'callback for a should not fire after unbind')
-  })
-})
-
-describe('combokeys.unbindGlobal', function () {
-  it('unbindGlobal removes the global binding', function () {
-    var spy = sinon.spy()
-    var combokeys = new Combokeys(document)
     var el = document.createElement('input')
     document.body.appendChild(el)
     require('../../plugins/global-bind')(combokeys)
@@ -115,11 +100,12 @@ describe('combokeys.unbindGlobal', function () {
     KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
     assert.equal(spy.callCount, 1, 'callback for a should fire')
 
-    combokeys.unbindGlobal('a')
+    combokeys.unbind('a')
     KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
     assert.equal(spy.callCount, 1, 'callback for a should not fire after unbindGlobal')
 
-    // If we now bind the same key, it's not bound globally
+    // If we now bind the same key without bindGlobal,
+    // it's not bound globally
     combokeys.bind('a', spy)
     KeyEvent.simulate('a'.charCodeAt(0), 65, undefined, el)
     assert.equal(spy.callCount, 1, 'callback for a should not fire in an input after bind')


### PR DESCRIPTION
The `global-bind` plugin contains a bug.

When you do `bindGlobal(someKey, callback, someAction)`, the internal state `globalCallbacks[someKey]` is set to `true`. If you later `unbind(someKey, someAction)`, that state is not cleared, so if you then do `bind(someKey, callback, someAction)`, it will still be a global binding.

This PR introduces an `unbindGlobal` function that removes the keys from `globalCallbacks`.