### PR TITLE
Removing ctrl+character and meta+character from any-character bind for ie and firefox

### DIFF
--- a/Combokeys/prototype/getMatches.js
+++ b/Combokeys/prototype/getMatches.js
@@ -26,6 +26,8 @@ module.exports = function (character, modifiers, e, sequenceName, combination, l
       action === 'keypress' &&
       // Firefox fires keypress for arrows
       !(e.code && e.code.slice(0, 5) === 'Arrow')
+      && !e.ctrlKey
+      && !e.metaKey
   ) {
     // 'any-character' callbacks are only on `keypress`
     var anyCharCallbacks = self.callbacks['any-character'] || []


### PR DESCRIPTION
ctrl+c is being picked up by 'any-character' bind on firefox and ie.   Someone reported fixing the issue on their own: https://github.com/avocode/combokeys/issues/49. 