### PR TITLE
add constructor option whether to globally store Combokeys instances

### DIFF
--- a/Combokeys/index.js
+++ b/Combokeys/index.js
@@ -1,9 +1,17 @@
 /* eslint-env node, browser */
 'use strict'
 
-module.exports = function (element) {
+module.exports = function (element, options) {
   var self = this
   var Combokeys = self.constructor
+
+  /**
+   * an object of passed options
+   *
+   * @type { storeInstancesGlobally?: true }
+   */
+
+  self.options = Object.assign({ storeInstancesGlobally: true }, options || {})
 
   /**
    * a list of all the callbacks setup via Combokeys.bind()
@@ -60,7 +68,10 @@ module.exports = function (element) {
 
   self.addEvents()
 
-  Combokeys.instances.push(self)
+  if (self.options.storeInstancesGlobally) {
+    Combokeys.instances.push(self)
+  }
+
   return self
 }
 

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+var Combokeys = require('..')
+var assert = require('proclaim')
+var makeElement = require('./helpers/make-element')
+var sinon = require('sinon')
+var KeyEvent = require('./lib/key-event')
+
+describe('combokeys.constructor', function () {
+  it('should store instances globally', function () {
+    var element = makeElement()
+    var spy = sinon.spy()
+    var combokeys = new Combokeys(element)
+    assert.strictEqual(Combokeys.instances.length, 1)
+  })
+
+  it('should not store instances globally', function () {
+    var element = makeElement()
+    var spy = sinon.spy()
+    var combokeys = new Combokeys(element, { storeInstancesGlobally: false })
+    assert.strictEqual(Combokeys.instances.length, 0)
+  })
+})


### PR DESCRIPTION
- adds option to not store globally instances of Mousetrap which si useful for DOM-dependant application but it causes memory leaks when static `Combokeys.reset()` is not called