### PR TITLE
add key code 171 to handle plus in firefox

### DIFF
--- a/helpers/special-keys-map.js
+++ b/helpers/special-keys-map.js
@@ -31,6 +31,7 @@ module.exports = {
   46: 'del',
   91: 'meta',
   93: 'meta',
+  171: 'plus',
   173: 'minus',
   187: 'plus',
   189: 'minus',


### PR DESCRIPTION
Similar to the "minus" issue which was solved in https://github.com/avocode/combokeys/commit/79ab448f67325b27dd806e461d4a372283b434ec

Firefox code for plus Is 171, while Chrome is 187